### PR TITLE
fix: prevent E95 error when BufReadCmd re-fires on external file change

### DIFF
--- a/lua/ipynvim/init.lua
+++ b/lua/ipynvim/init.lua
@@ -164,6 +164,20 @@ function M.open(bufnr, filepath)
   -- Normalise to absolute path.
   filepath = vim.fn.fnamemodify(filepath, ":p")
 
+  -- Tear down any existing session for this buffer.
+  -- BufReadCmd re-fires when an external tool modifies the file (e.g. Claude Code,
+  -- :e! reload). Without cleanup the LSP hidden buffers still exist but their
+  -- state entry may have been cleared, causing E95 on the next lsp.create() call.
+  if buf_states[bufnr] and buf_states[bufnr].model then
+    local prev = buf_states[bufnr]
+    if prev.focus_au_id then
+      pcall(vim.api.nvim_del_autocmd, prev.focus_au_id)
+    end
+    require("ipynvim.output").clear_all(bufnr)
+    lsp.destroy(bufnr)
+    drop_state(bufnr)
+  end
+
   -- Parse the notebook file.
   local model, err = parser.parse(filepath)
   if not model then

--- a/lua/ipynvim/lsp.lua
+++ b/lua/ipynvim/lsp.lua
@@ -177,6 +177,15 @@ local function create_hidden_buf(notebook_bufnr, filetype, ext)
   local notebook_path = vim.api.nvim_buf_get_name(notebook_bufnr)
   local notebook_dir = vim.fn.fnamemodify(notebook_path, ":h")
   local buf_name = string.format("%s/.ipynvim_%d%s", notebook_dir, notebook_bufnr, ext)
+
+  -- Evict any orphaned buffer still holding this name.  This can happen when
+  -- BufReadCmd fires a second time (external edit) and LSP state was cleared
+  -- without the hidden buffer being deleted (E95 guard).
+  local orphan = vim.fn.bufnr(buf_name)
+  if orphan ~= -1 then
+    pcall(vim.api.nvim_buf_delete, orphan, { force = true })
+  end
+
   vim.api.nvim_buf_set_name(hidden_bufnr, buf_name)
 
   vim.bo[hidden_bufnr].bufhidden = "wipe"


### PR DESCRIPTION
Fixes #1

## Problem

When an external tool (Claude Code, Jupyter, etc.) modifies an open `.ipynb` file, Neovim re-fires `BufReadCmd` for the same buffer. This caused an E95 error in `lsp.lua` because the hidden LSP proxy buffers (`.ipynvim_<bufnr>.py` / `.ipynvim_<bufnr>.md`) still occupied their names while the `lsp.state` entry had been cleared, leaving `lsp.create()` unable to set the buffer name.

## Changes

**`init.lua`** — root fix: explicitly tear down the previous session at the start of `M.open()` when called on an already-initialised buffer:
- Delete the `FocusGained` autocmd (`focus_au_id`) to prevent accumulation across reloads
- Call `output.clear_all()`, `lsp.destroy()`, `drop_state()` before re-initialising

**`lsp.lua`** — defensive fallback: in `create_hidden_buf`, evict any buffer still holding the expected name before calling `nvim_buf_set_name`, guarding against any future state/buffer liveness mismatch