### PR TITLE
fix: use display width for output truncation to prevent garbled UTF-8

### DIFF
--- a/lua/ipynvim/output.lua
+++ b/lua/ipynvim/output.lua
@@ -65,10 +65,25 @@ local function strip_ansi(s)
 end
 
 local function truncate(s, max_width)
-  if #s <= max_width then
+  if vim.fn.strdisplaywidth(s) <= max_width then
     return s
   end
-  return s:sub(1, max_width - 3) .. "..."
+  -- Walk character by character so that multi-byte UTF-8 sequences (e.g. box-
+  -- drawing characters like ┬ ╪ which are 3 bytes but 1 display column) are
+  -- never split at a byte boundary, which would produce garbled output (<e2><94>…).
+  local width = 0
+  local char_idx = 0
+  local nchars = vim.fn.strcharlen(s)
+  while char_idx < nchars do
+    local ch = vim.fn.strcharpart(s, char_idx, 1)
+    local cw = vim.fn.strdisplaywidth(ch)
+    if width + cw > max_width - 3 then
+      break
+    end
+    width = width + cw
+    char_idx = char_idx + 1
+  end
+  return vim.fn.strcharpart(s, 0, char_idx) .. "..."
 end
 
 --- Append a single line to virt_chunks and plain_texts.


### PR DESCRIPTION
Fixes #3

## Problem

Cell output containing multi-byte UTF-8 characters (box-drawing characters used in Polars tables: `┬`, `╪`, `┆`, etc.) was rendered as garbled bytes like `<e2><94>`.

The old `truncate()` used `#s` (byte length) for the width check and `s:sub(1, n)` for cutting. A line of ~85 display columns can have a byte length of 200+ when it contains box-drawing characters (3 bytes each). With `max_output_width = 140`, the byte check fired and `s:sub(1, 137)` split a 3-byte sequence mid-character.

## Fix

Replace byte-based operations with display-width-aware ones:

- `#s` → `vim.fn.strdisplaywidth(s)`
- `s:sub(1, n)` → character-by-character walk with `vim.fn.strcharpart()` + `vim.fn.strdisplaywidth()` per character

`max_output_width` now correctly means **display columns**, not bytes.